### PR TITLE
make wine build on x86_32

### DIFF
--- a/include/windef.h
+++ b/include/windef.h
@@ -25,6 +25,10 @@
 #define WINVER 0x0500
 #endif
 
+#ifdef __HAIKU__
+	#include <stdarg.h>
+#endif
+
 #ifndef NO_STRICT
 # ifndef STRICT
 #  define STRICT


### PR DESCRIPTION
I tried building wine on haiku x86_32. It compiled after some changes, however when running it errors out with  `No LDT support on this platform`.
I mostly stubbed the `dlls/ntdll/unix/signal_i386.c`, so half of the signal contexts are replaced with NULL, and I'll have to figure out how to use new_extended_regs